### PR TITLE
Fix : Plugin not working on Firefox

### DIFF
--- a/resources/assets/scripts/main.js
+++ b/resources/assets/scripts/main.js
@@ -1,7 +1,9 @@
-(function($){
-  $(document).ready(function() {
-    if ($('.acf-field-wpeditor').length) {
-      $('.acf-field-wpeditor .acf-input').append($('#postdivrich'));
+(function ($) {
+  $(document).ready(function () {
+    if ($(".acf-field-wpeditor").length) {
+      $("#postdivrich").on("load", function () {
+        $(".acf-field-wpeditor .acf-input").append($("#postdivrich"));
+      });
     }
   });
 })(jQuery);


### PR DESCRIPTION
PR to address a bug with recent versions of Wordpress (observed using WP 5.8+), using Firefox. The body of the iframe would be empty (probably moved before it was loaded).